### PR TITLE
Add scheduled GitHub metrics workflow and refresh README with stats banner

### DIFF
--- a/.github/workflows/metrics.yaml
+++ b/.github/workflows/metrics.yaml
@@ -1,0 +1,35 @@
+name: Metrics
+
+on:
+  schedule:
+    - cron: "0 */12 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  github-metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub Metrics
+        uses: lowlighter/metrics@latest
+        with:
+          token: ${{ secrets.METRICS_TOKEN || github.token }}
+          user: adisakshya
+          filename: github-metrics.svg
+          config_timezone: UTC
+          template: classic
+          base: header, activity, community, repositories, metadata
+          plugin_isocalendar: yes
+          plugin_isocalendar_duration: full-year
+          plugin_languages: yes
+          plugin_languages_analysis_timeout: 15
+          plugin_languages_categories: markup, programming
+          plugin_languages_limit: 8
+          plugin_stars: yes
+          plugin_traffic: yes

--- a/README.md
+++ b/README.md
@@ -1,11 +1,23 @@
-[![Linkedin badge](https://img.shields.io/badge/-adisakshya-blue?style=flat&logo=linkedin&logoColor=white)](https://www.linkedin.com/in/adisakshya)
-[![Website Badge](https://img.shields.io/badge/-adisakshya.github.io-purple?style=flat&logo=firefox&logoColor=white&link=https://adisakshya.github.io)](https://adisakshya.github.io)
-[![Twitter Badge](https://img.shields.io/badge/-adisakshya-00acee?style=flat&logo=twitter&logoColor=white&link=https://twitter.com/adisakshya)](https://www.twitter.com/adisakshya)
+<p align="center">
+  <img src="https://capsule-render.vercel.app/api?type=waving&color=0:0f2027,50:203a43,100:2c5364&height=220&section=header&text=adisakshya&fontSize=60&fontColor=ffffff&animation=fadeIn&fontAlignY=38&descAlignY=55" alt="adisakshya banner" />
+</p>
 
-## 🏆 Trophies
+<p align="center">
+  <img src="https://github-readme-stats.vercel.app/api?username=adisakshya&show_icons=true&theme=tokyonight&hide_border=true&rank_icon=github" alt="GitHub Stats" />
+</p>
 
-<div>
-  <img src="https://github-profile-trophy.vercel.app/?username=adisakshya&title=MultiLanguage,Commit,Followers,Repositories,PullRequest,Issues&column=7&margin-w=15&margin-h=15"/>
-</div>
+<p align="center">
+  <img src="https://github-readme-streak-stats.herokuapp.com/?user=adisakshya&theme=tokyonight&hide_border=true" alt="GitHub Streak" />
+</p>
 
-<br/>
+<p align="center">
+  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=adisakshya&layout=compact&theme=tokyonight&hide_border=true" alt="Top Languages" />
+</p>
+
+<p align="center">
+  <img src="https://github-readme-activity-graph.vercel.app/graph?username=adisakshya&theme=tokyo-night&hide_border=true&area=true" alt="Contribution Graph" />
+</p>
+
+<p align="center">
+  <img src="https://github-profile-trophy.vercel.app/?username=adisakshya&theme=tokyonight&no-frame=true&no-bg=true&margin-w=10&margin-h=10&column=7" alt="GitHub Trophies" />
+</p>


### PR DESCRIPTION
### Motivation
- Provide automated generation of GitHub metrics and a more visual project README header to showcase activity and stats. 

### Description
- Add a new GitHub Actions workflow `/.github/workflows/metrics.yaml` that runs `lowlighter/metrics@latest` on a schedule (cron `0 */12 * * *`), on push to `main`/`master`, and via `workflow_dispatch`, with `contents: write` permission.
- Configure the workflow to output `github-metrics.svg` and enable plugins including `isocalendar`, `languages` (with timeout and limits), `stars`, and `traffic`, using `secrets.METRICS_TOKEN || github.token` as the token.
- Replace the plain badge section in `README.md` with a centered banner and visual stats images including GitHub stats, streak, top languages, contribution graph, and trophies for a modernized profile presentation.

### Testing
- No automated unit tests were run as part of this change. 
- The new workflow is configured to run on schedule and on push; functionality can be validated when the workflow executes in GitHub Actions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb41969bc8321a164a721c95b57bd)