### PR TITLE
docs: use 2x Carbon profile image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
-<picture>
-  <source
-    media="(prefers-color-scheme: dark)"
-    srcset="./assets/profile-dark.svg"
-  />
-  <img
-    width="100%"
-    alt="Terminal-style profile summary for Adisakshya Chauhan"
-    src="./assets/profile-light.svg"
-  />
-</picture>
+<img
+  width="100%"
+  alt="Profile summary for Adisakshya Chauhan"
+  src="./assets/carbon-2x.svg"
+/>
 
 <p align="center">
   <a href="https://adisakshya.github.io/weblog/">Blog</a>


### PR DESCRIPTION
### Motivation
- Use the uploaded Carbon export as the README profile image instead of the theme-specific SVGs so the README shows the newly generated, higher-resolution Carbon artwork.

### Description
- Replace the `<picture>` block that referenced `./assets/profile-dark.svg` and `./assets/profile-light.svg` with a single full-width `<img>` pointing at `./assets/carbon-2x.svg` and update the `alt` text accordingly.

### Testing
- Ran `python scripts/validate_profile_assets.py` which printed `Validation passed.` and exited with success.
- Ran `git diff --check` which reported no issues.
- Verified the repository working tree was clean after committing the change with `git status --short --branch`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bcdabfb208321918d759e612e9308)